### PR TITLE
feat: add provider selection and provider-based AMQP routing

### DIFF
--- a/src/broker.ts
+++ b/src/broker.ts
@@ -17,7 +17,7 @@ import {
   UNOAPI_QUEUE_TRANSCRIBER,
 } from './defaults'
 
-import { amqpConsume } from './amqp'
+import { amqpConsume, amqpGetChannel, extractRoutingKeyFromBindingKey } from './amqp'
 import { startRedis } from './services/redis'
 import { OutgoingCloudApi } from './services/outgoing_cloud_api'
 import { getConfigRedis } from './services/config_redis'
@@ -37,6 +37,11 @@ import { addToBlacklist } from './jobs/add_to_blacklist'
 import { TimerJob } from './jobs/timer'
 import { TranscriberJob } from './jobs/transcriber'
 import { OutgoingAmqp } from './services/outgoing_amqp'
+import { IncomingBaileys } from './services/incoming_baileys'
+import { getClientBaileys } from './services/client_baileys'
+import { onNewLoginGenerateToken } from './services/on_new_login_generate_token'
+import { ListenerAmqp } from './services/listener_amqp'
+import { IncomingJob } from './jobs/incoming'
 
 const incomingAmqp: Incoming = new IncomingAmqp(getConfigRedis)
 const outgoingCloudApi: Outgoing = new OutgoingCloudApi(getConfigRedis, isInBlacklistInRedis)
@@ -114,6 +119,29 @@ const startBroker = async () => {
 
   logger.info('Starting blacklist add consumer %s', UNOAPI_SERVER_NAME)
   await amqpConsume(UNOAPI_EXCHANGE_BROKER_NAME, UNOAPI_QUEUE_BLACKLIST_ADD, '*', addToBlacklist, { notifyFailedMessages, prefetch, type: 'topic' })
+
+  // Consume provider-specific outgoing messages for Baileys sessions
+  const channel = await amqpGetChannel()
+  await channel.assertExchange('unoapi.outgoing', 'topic', { durable: true })
+  await channel.assertQueue('outgoing.baileys', { durable: true })
+  await channel.bindQueue('outgoing.baileys', 'unoapi.outgoing', 'provider.baileys.*')
+  const listenerAmqpWorker = new ListenerAmqp()
+  const onNewLogin = onNewLoginGenerateToken(outgoingCloudApi)
+  const incomingBaileysWorker = new IncomingBaileys(listenerAmqpWorker, getConfigRedis, getClientBaileys, onNewLogin)
+  const providerJob = new IncomingJob(incomingBaileysWorker, outgoingAmqp, getConfigRedis)
+  channel.consume('outgoing.baileys', async (payload) => {
+    if (!payload) {
+      return
+    }
+    const phone = extractRoutingKeyFromBindingKey(payload.fields.routingKey)
+    const data = JSON.parse(payload.content.toString())
+    try {
+      await providerJob.consume(phone, data)
+    } catch (error) {
+      logger.error(error, 'Error consuming provider.baileys message')
+    }
+    channel.ack(payload)
+  })
 
   logger.info('Unoapi Cloud version %s started broker!', version)
 }

--- a/src/controllers/phone_number_controller.ts
+++ b/src/controllers/phone_number_controller.ts
@@ -21,6 +21,7 @@ export class PhoneNumberController {
     try {
       const { phone } = req.params
       const config = await this.getConfig(phone)
+      config.provider = config.provider || 'baileys'
       const store = await config.getStore(phone, config)
       logger.debug('Session store retrieved!')
       const { sessionStore } = store
@@ -50,6 +51,7 @@ export class PhoneNumberController {
       for (let i = 0, j = phones.length; i < j; i++) {
         const phone = phones[i]
         const config = await this.getConfig(phone)
+        config.provider = config.provider || 'baileys'
         const store = await config.getStore(phone, config)
         const { sessionStore } = store
         const status = config.provider == 'forwarder' ? 'forwarder' : await sessionStore.getStatus(phone)

--- a/src/controllers/session_command_controller.ts
+++ b/src/controllers/session_command_controller.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from 'express'
+import axios from 'axios'
+import { getConfig } from '../services/config'
+import { Reload } from '../services/reload'
+import { Logout } from '../services/logout'
+import { WHATSOMEOW_ADAPTER_BASEURL } from '../defaults'
+import logger from '../services/logger'
+
+export class SessionCommandController {
+  private getConfig: getConfig
+  private reloader: Reload
+  private logout: Logout
+
+  constructor(getConfig: getConfig, reload: Reload, logout: Logout) {
+    this.getConfig = getConfig
+    this.reloader = reload
+    this.logout = logout
+  }
+
+  public async connect(req: Request, res: Response) {
+    const { phone } = req.params
+    try {
+      const config = await this.getConfig(phone)
+      const provider = config.provider || 'baileys'
+      if (provider === 'whatsmeow') {
+        await axios.post(`${WHATSOMEOW_ADAPTER_BASEURL}/sessions/${phone}/connect`)
+        return res.status(204).send()
+      }
+      await this.reloader.run(phone)
+      return res.status(204).send()
+    } catch (e) {
+      logger.error(e, 'Error on connect session %s', phone)
+      return res.status(500).json({ status: 'error', message: e.message })
+    }
+  }
+
+  public async disconnect(req: Request, res: Response) {
+    const { phone } = req.params
+    try {
+      const config = await this.getConfig(phone)
+      const provider = config.provider || 'baileys'
+      if (provider === 'whatsmeow') {
+        await axios.post(`${WHATSOMEOW_ADAPTER_BASEURL}/sessions/${phone}/disconnect`)
+        return res.status(204).send()
+      }
+      await this.logout.run(phone)
+      return res.status(204).send()
+    } catch (e) {
+      logger.error(e, 'Error on disconnect session %s', phone)
+      return res.status(500).json({ status: 'error', message: e.message })
+    }
+  }
+
+  public async reload(req: Request, res: Response) {
+    const { phone } = req.params
+    try {
+      const config = await this.getConfig(phone)
+      const provider = config.provider || 'baileys'
+      if (provider === 'whatsmeow') {
+        await axios.post(`${WHATSOMEOW_ADAPTER_BASEURL}/sessions/${phone}/reload`)
+        return res.status(204).send()
+      }
+      await this.reloader.run(phone)
+      return res.status(204).send()
+    } catch (e) {
+      logger.error(e, 'Error on reload session %s', phone)
+      return res.status(500).json({ status: 'error', message: e.message })
+    }
+  }
+
+  public async qr(req: Request, res: Response) {
+    const { phone } = req.params
+    try {
+      const config = await this.getConfig(phone)
+      const provider = config.provider || 'baileys'
+      if (provider === 'whatsmeow') {
+        const response = await axios.get(`${WHATSOMEOW_ADAPTER_BASEURL}/sessions/${phone}/qr`, {
+          responseType: 'arraybuffer',
+        })
+        const base64 = Buffer.from(response.data, 'binary').toString('base64')
+        return res.status(200).send(base64)
+      }
+      return res.status(404).json({ status: 'error', message: 'QR not supported for provider' })
+    } catch (e) {
+      logger.error(e, 'Error on get qr for session %s', phone)
+      return res.status(500).json({ status: 'error', message: e.message })
+    }
+  }
+}
+

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -26,6 +26,8 @@ export const WEBHOOK_FORWARD_TIMEOUT_MS = parseInt(process.env.WEBHOOK_TIMEOUT_M
 
 // comunication
 export const UNOAPI_URL = process.env.UNOAPI_URL || 'http://localhost:9876'
+export const WHATSOMEOW_ADAPTER_BASEURL =
+  process.env.WHATSOMEOW_ADAPTER_BASEURL || 'http://provider-whatsmeow:8080'
 export const WEBHOOK_URL_ABSOLUTE = process.env.WEBHOOK_URL_ABSOLUTE || ''
 export const WEBHOOK_URL = process.env.WEBHOOK_URL || 'http://localhost:9876/webhooks/fake'
 export const WEBHOOK_HEADER = process.env.WEBHOOK_HEADER || 'Authorization'

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,6 +20,7 @@ import { SessionController } from './controllers/session_controller'
 import { BlacklistController } from './controllers/blacklist_controller'
 import { PairingCodeController } from './controllers/pairing_code_controller'
 import { ConnectController } from './controllers/connect_controller'
+import { SessionCommandController } from './controllers/session_command_controller'
 import { Server } from 'socket.io'
 import { OnNewLogin } from './services/socket'
 import { addToBlacklist } from './services/blacklist'
@@ -60,6 +61,7 @@ export const router = (
   const pairingCodeController = new PairingCodeController(getConfig, incoming)
   const connectController = new ConnectController(reload)
   const timerController = new TimerController()
+  const sessionCommandController = new SessionCommandController(getConfig, reload, logout)
 
   // Webhook for forward connection
   router.post('/webhooks/whatsapp/:phone', webhookController.whatsapp.bind(webhookController))
@@ -78,6 +80,10 @@ export const router = (
   router.get('/:version/debug_token', indexController.debugToken)
   router.get('/sessions', middleware, phoneNumberController.list.bind(phoneNumberController))
   router.get('/sessions/:phone', sessionController.index.bind(sessionController))
+  router.post('/sessions/:phone/connect', middleware, sessionCommandController.connect.bind(sessionCommandController))
+  router.post('/sessions/:phone/disconnect', middleware, sessionCommandController.disconnect.bind(sessionCommandController))
+  router.post('/sessions/:phone/reload', middleware, sessionCommandController.reload.bind(sessionCommandController))
+  router.get('/sessions/:phone/qr', sessionCommandController.qr.bind(sessionCommandController))
   router.post('/:phone/contacts', middleware, contactsController.post.bind(contactsController))
   router.post('/:version/:phone/register', middleware, registrationController.register.bind(registrationController))
   router.post('/:version/:phone/deregister', middleware, registrationController.deregister.bind(registrationController))

--- a/src/services/auto_connect.ts
+++ b/src/services/auto_connect.ts
@@ -20,7 +20,7 @@ export const autoConnect = async (
       const phone = phones[i]
       try {
         const config = await getConfig(phone)
-        if (config.provider && !['forwarder', 'baileys'].includes(config.provider)) {
+        if (config.provider && !['forwarder', 'baileys', 'whatsmeow'].includes(config.provider)) {
           logger.info(`Ignore connecting phone ${phone} provider ${config.provider}...`)
           continue
         }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -72,7 +72,7 @@ export type Config = {
   sendProfilePicture: boolean
   authToken: string | undefined
   authHeader: string | undefined
-  provider: 'baileys' | 'forwarder' | undefined
+  provider: 'baileys' | 'whatsmeow' | 'forwarder' | undefined
   server: string | undefined
   connectionType: connectionType
   wavoipToken: string | undefined
@@ -138,7 +138,7 @@ export const defaultConfig: Config = {
   proxyUrl: undefined,
   authToken: undefined,
   authHeader: undefined,
-  provider: undefined,
+  provider: 'baileys',
   server: undefined,
   connectionType: 'qrcode',
   wavoipToken: '',

--- a/src/services/incoming_amqp.ts
+++ b/src/services/incoming_amqp.ts
@@ -16,9 +16,9 @@ const initExchange = async () => {
   await channel.assertQueue('outgoing.baileys', { durable: true })
   await channel.bindQueue('outgoing.baileys', EXCHANGE, 'provider.baileys.*')
   await channel.assertQueue('outgoing.baileys.dlq', { durable: true })
-  await channel.assertQueue('outgoing.whatsmeow', { durable: true })
+  await channel.assertQueue('outgoing.whatsmeow', { durable: true, exclusive: false })
   await channel.bindQueue('outgoing.whatsmeow', EXCHANGE, 'provider.whatsmeow.*')
-  await channel.assertQueue('outgoing.whatsmeow.dlq', { durable: true })
+  await channel.assertQueue('outgoing.whatsmeow.dlq', { durable: true, exclusive: false })
   initialized = true
 }
 

--- a/src/services/incoming_amqp.ts
+++ b/src/services/incoming_amqp.ts
@@ -1,9 +1,26 @@
 import { Incoming } from './incoming'
-import { amqpPublish } from '../amqp'
-import { UNOAPI_EXCHANGE_BRIDGE_NAME, UNOAPI_QUEUE_INCOMING } from '../defaults'
+import { amqpGetChannel } from '../amqp'
 import { v1 as uuid } from 'uuid'
 import { jidToPhoneNumber } from './transformer'
 import { getConfig } from './config'
+
+const EXCHANGE = 'unoapi.outgoing'
+let initialized = false
+
+const initExchange = async () => {
+  if (initialized) {
+    return
+  }
+  const channel = await amqpGetChannel()
+  await channel.assertExchange(EXCHANGE, 'topic', { durable: true })
+  await channel.assertQueue('outgoing.baileys', { durable: true })
+  await channel.bindQueue('outgoing.baileys', EXCHANGE, 'provider.baileys.*')
+  await channel.assertQueue('outgoing.baileys.dlq', { durable: true })
+  await channel.assertQueue('outgoing.whatsmeow', { durable: true })
+  await channel.bindQueue('outgoing.whatsmeow', EXCHANGE, 'provider.whatsmeow.*')
+  await channel.assertQueue('outgoing.whatsmeow.dlq', { durable: true })
+  initialized = true
+}
 
 export class IncomingAmqp implements Incoming {
   private getConfig: getConfig
@@ -16,18 +33,31 @@ export class IncomingAmqp implements Incoming {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { status, type, to } = payload as any
     const config = await this.getConfig(phone)
+    const provider = config.provider || 'baileys'
+    await initExchange()
+    const channel = await amqpGetChannel()
+    const routingKey = `provider.${provider}.${phone}`
     if (status) {
       options['type'] = 'direct'
       options['priority'] = 3 // update status is always middle important
-      await amqpPublish(UNOAPI_EXCHANGE_BRIDGE_NAME, `${UNOAPI_QUEUE_INCOMING}.${config.server!}`, phone, { payload, options }, options)
+      const data = { payload, options }
+      channel.publish(EXCHANGE, routingKey, Buffer.from(JSON.stringify(data)), {
+        contentType: 'application/json',
+        messageId: (payload as any).message_id,
+        persistent: true,
+      })
       return { ok: { success: true } }
     } else if (type) {
       const id = uuid()
       if (!options['priority']) {
         options['priority'] = 5 // send message without bulk is very important
       }
-      options['type'] = 'direct'
-      await amqpPublish(UNOAPI_EXCHANGE_BRIDGE_NAME, `${UNOAPI_QUEUE_INCOMING}.${config.server!}`, phone, { payload, id, options }, options)
+      const data = { payload, id, options }
+      channel.publish(EXCHANGE, routingKey, Buffer.from(JSON.stringify(data)), {
+        contentType: 'application/json',
+        messageId: id,
+        persistent: true,
+      })
       const ok = {
         messaging_product: 'whatsapp',
         contacts: [

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -61,7 +61,7 @@ import { Reload } from './services/reload'
 import { Logout } from './services/logout'
 import { LogoutAmqp } from './services/logout_amqp'
 import { ReloadJob } from './jobs/reload'
-import { amqpConnect, amqpConsume } from './amqp'
+import { amqpConnect, amqpConsume, amqpGetChannel, extractRoutingKeyFromBindingKey } from './amqp'
 import { startRedis } from './services/redis'
 import ContactBaileys from './services/contact_baileys'
 import injectRouteDummy from './services/inject_route_dummy'
@@ -72,6 +72,7 @@ import atbl from './jobs/add_to_blacklist'
 import { MediaJob } from './jobs/media'
 import { OutgoingJob } from './jobs/outgoing'
 import { NotificationJob } from './jobs/notification'
+import { IncomingJob } from './jobs/incoming'
 
 import * as Sentry from '@sentry/node'
 if (process.env.SENTRY_DSN) {
@@ -157,6 +158,29 @@ if (process.env.AMQP_URL) {
 
   logger.info('Starting blacklist add consumer %s', UNOAPI_SERVER_NAME)
   amqpConsume(UNOAPI_EXCHANGE_BROKER_NAME, UNOAPI_QUEUE_BLACKLIST_ADD, '*', atbl, { notifyFailedMessages, prefetch, type: 'topic' })
+
+  // Consume provider-specific outgoing messages for Baileys sessions
+  ;(async () => {
+    const channel = await amqpGetChannel()
+    await channel.assertExchange('unoapi.outgoing', 'topic', { durable: true })
+    await channel.assertQueue('outgoing.baileys', { durable: true })
+    await channel.bindQueue('outgoing.baileys', 'unoapi.outgoing', 'provider.baileys.*')
+    const incomingBaileysWorker = new IncomingBaileys(listener, getConfigVar, getClientBaileys, onNewLoginn)
+    const providerJob = new IncomingJob(incomingBaileysWorker, outgoing, getConfigVar)
+    channel.consume('outgoing.baileys', async (payload) => {
+      if (!payload) {
+        return
+      }
+      const phone = extractRoutingKeyFromBindingKey(payload.fields.routingKey)
+      const data = JSON.parse(payload.content.toString())
+      try {
+        await providerJob.consume(phone, data)
+      } catch (error) {
+        logger.error(error, 'Error consuming provider.baileys message')
+      }
+      channel.ack(payload)
+    })
+  })()
 } else {
   logger.info('Starting standard mode')
 }


### PR DESCRIPTION
## Summary
- allow sessions to specify `provider` (`baileys`, `whatsmeow`, or `forwarder`)
- publish outgoing messages using provider-based AMQP exchange
- expose provider in session endpoints and auto-connect
- delegate connect/disconnect/reload/qr commands to Whatsmeow adapter when provider is `whatsmeow`
- fix session command routes by separating reloader service from handler method
- consume provider-specific outgoing queue so Baileys messages are delivered
- consume Baileys routing queue in broker to forward messages from `outgoing.baileys`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb693305f48324bf115c2669e2232a