### PR TITLE
feat: include media url for whatsmeow provider

### DIFF
--- a/src/services/transformer.ts
+++ b/src/services/transformer.ts
@@ -608,6 +608,12 @@ export const fromBaileysMessageContent = (phone: string, payload: any, config?: 
           // url: binMessage.url && binMessage.url.indexOf('base64') < 0 ? binMessage.url : '',
           id: mediaKey,
         }
+        if (config?.provider === 'whatsmeow' && config?.server) {
+          const filePath = `${phone}/${whatsappMessageId}.${extension}`
+          const downloadUrl = `${config.server}/v15.0/download/${filePath}`
+          message[mediaType].link = downloadUrl
+          message[mediaType].url = downloadUrl
+        }
         message.type = mediaType
         break
 


### PR DESCRIPTION
## Summary
- ensure media messages from whatsmeow include downloadable url
- test transformer adds media url when provider is whatsmeow

## Testing
- `npm run lint -- src/services/transformer.ts __tests__/services/transformer.ts` *(fails: prettier.resolveConfig.sync is not a function)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7babce588324b2ee56ffd219cb7e