### PR TITLE
Infer missing media mime type during lookup

### DIFF
--- a/__tests__/services/media_store_file.ts
+++ b/__tests__/services/media_store_file.ts
@@ -25,15 +25,36 @@ describe('media routes', () => {
   let mediaStore: MediaStore
 
   beforeEach(() => {
-    dataStore.loadMediaPayload.mockReturnValue(new Promise((resolve) => resolve(message)))
+    dataStore.loadMediaPayload.mockReset()
     mediaStore = getMediaStoreFile(phone, defaultConfig, getTestDataStore)
   })
 
   test('getMedia', async () => {
+    dataStore.loadMediaPayload.mockResolvedValueOnce(message)
     const response = {
       url: `${url}/v15.0/download/${phone}/${messageId}.${extension}`,
       ...message,
     }
     expect(await mediaStore.getMedia(url, messageId)).toStrictEqual(response)
+  })
+
+  test('getMedia without mime type', async () => {
+    const payload = {
+      messaging_product: 'whatsapp',
+      id: `${phone}/${messageId}`,
+      filename: `${messageId}.${extension}`,
+    }
+    dataStore.loadMediaPayload.mockResolvedValueOnce(payload)
+    const response = {
+      url: `${url}/v15.0/download/${phone}/${messageId}.${extension}`,
+      ...payload,
+      mime_type: mimetype,
+    }
+    expect(await mediaStore.getMedia(url, messageId)).toStrictEqual(response)
+  })
+
+  test('getMedia not found', async () => {
+    dataStore.loadMediaPayload.mockResolvedValueOnce(undefined)
+    expect(await mediaStore.getMedia(url, messageId)).toBeUndefined()
   })
 })

--- a/src/services/media_store_file.ts
+++ b/src/services/media_store_file.ts
@@ -2,6 +2,7 @@ import { proto, WAMessage, downloadMediaMessage, Contact } from 'baileys'
 import { getBinMessage, jidToPhoneNumberIfUser, toBuffer } from './transformer'
 import { writeFile } from 'fs/promises'
 import { existsSync, mkdirSync, rmSync, createReadStream } from 'fs'
+import path from 'path'
 import { MediaStore, getMediaStore, mediaStores } from './media_store'
 import mime from 'mime-types'
 import { Response } from 'express'
@@ -145,10 +146,32 @@ export const mediaStoreFile = (phone: string, config: Config, getDataStore: getD
   mediaStore.getMedia = async (baseUrl: string, mediaId: string) => {
     const dataStore = await getDataStore(phone, config)
     const mediaPayload = await dataStore.loadMediaPayload(mediaId!)
-    const filePath = mediaStore.getFilePath(phone, mediaId!, mediaPayload.mime_type!)
+    if (!mediaPayload) {
+      logger.warn('Media payload not found %s', mediaId)
+      return undefined
+    }
+
+    let filePath: string | undefined
+    if (mediaPayload.mime_type) {
+      filePath = mediaStore.getFilePath(phone, mediaId!, mediaPayload.mime_type)
+    } else if (mediaPayload.filename) {
+      logger.debug('Missing mime type for media %s, deriving from filename', mediaId)
+      const ext = path.extname(mediaPayload.filename)
+      if (ext) {
+        filePath = `${phone}/${mediaId}${ext}`
+      }
+    }
+
+    if (!filePath) {
+      logger.warn('Media payload missing mime type and filename %s', mediaId)
+      return undefined
+    }
+
     const url = await mediaStore.getDownloadUrl(baseUrl, filePath)
+    const mimeType = mediaPayload.mime_type || mime.lookup(filePath)
     const payload = {
       ...mediaPayload,
+      ...(mimeType ? { mime_type: mimeType } : {}),
       url,
     }
     return payload


### PR DESCRIPTION
## Summary
- derive media path and mime type from filename when `mime_type` is absent
- cover fallback logic with unit test

## Testing
- `yarn lint && echo lint-ok`
- `yarn test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68bfa858c9848324b82f1ac2c4813ddf