### PR TITLE
feat: store whatsmeow media in redis

### DIFF
--- a/__tests__/routes/webook.ts
+++ b/__tests__/routes/webook.ts
@@ -10,6 +10,8 @@ import { OnNewLogin } from '../../src/services/socket'
 import { addToBlacklist } from '../../src/services/blacklist'
 import { Reload } from '../../src/services/reload'
 import { Logout } from '../../src/services/logout'
+import { DataStore } from '../../src/services/data_store'
+import { Store } from '../../src/services/store'
 const addToBlacklist = mock<addToBlacklist>()
 
 const sessionStore = mock<SessionStore>()
@@ -28,5 +30,48 @@ describe('webhook routes', () => {
     const app: App = new App(incoming, outgoing, '', getConfigTest, sessionStore, onNewLogin, addToBlacklist, reload, logout)
     const res = await request(app.server).post('/webhooks/whatsapp/123')
     expect(res.status).toEqual(200)
+  })
+
+  test('whatsapp saves media for whatsmeow', async () => {
+    const incoming = mock<Incoming>()
+    const outgoing = mock<Outgoing>()
+    const onNewLogin = mock<OnNewLogin>()
+    const reload = mock<Reload>()
+    const logout = mock<Logout>()
+    const dataStore = mock<DataStore>()
+    const store = mock<Store>()
+    store.dataStore = dataStore
+    const getConfigWhatsmeow: getConfig = async (_phone: string) => {
+      return {
+        ...defaultConfig,
+        provider: 'whatsmeow',
+        getStore: async () => store,
+      }
+    }
+    const app: App = new App(incoming, outgoing, '', getConfigWhatsmeow, sessionStore, onNewLogin, addToBlacklist, reload, logout)
+    const body = {
+      messages: [
+        {
+          from: '5562933000233',
+          id: '3AF7675E18E861BEF49C',
+          image: {
+            caption: '',
+            id: '553121159080/3AF7675E18E861BEF49C',
+            mime_type: 'image/jpeg',
+            sha256: 'hash',
+          },
+          timestamp: '1757459817',
+          type: 'image',
+        },
+      ],
+    }
+    await request(app.server).post('/webhooks/whatsapp/123').send(body).expect(200)
+    expect(dataStore.setMediaPayload).toHaveBeenCalledWith('3AF7675E18E861BEF49C', {
+      messaging_product: 'whatsapp',
+      caption: '',
+      id: '553121159080/3AF7675E18E861BEF49C',
+      mime_type: 'image/jpeg',
+      sha256: 'hash',
+    })
   })
 })


### PR DESCRIPTION
## Summary
- save whatsmeow media metadata to redis on incoming webhooks
- test webhook media mapping

## Testing
- `./node_modules/.bin/eslint src/controllers/webhook_controller.ts __tests__/routes/webook.ts` *(fails: prettier.resolveConfig.sync is not a function)*
- `./node_modules/.bin/jest __tests__/routes/webook.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c0d971942083248641b6b5712c33a8